### PR TITLE
Switching from $.append() to $.html()

### DIFF
--- a/jquery.keyframes.js
+++ b/jquery.keyframes.js
@@ -64,7 +64,7 @@
             var $frameStyle = $("style#" + frameData.name);
 
             if ($frameStyle.length > 0) {
-                $frameStyle.append(css);
+                $frameStyle.html(css);
 
                 var $elems = $("*").filter(function() {
                     return this.style[animationString + "Name"] === frameName;


### PR DESCRIPTION
to prevent same-named definitions from appending to each other.

Original issue described here with before & after:
https://github.com/Keyframes/jQuery.Keyframes/issues/49